### PR TITLE
Feature/fr-373 poap gallery change core api url

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 REACT_APP_MAINNET_SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/poap-xyz/poap
 REACT_APP_XDAI_SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/poap-xyz/poap-xdai
-REACT_APP_POAP_API_URL=https://api.poap.xyz
+REACT_APP_POAP_API_URL=https://api.poap.tech
 REACT_APP_RPC_PROVIDER_URL=https://mainnet.infura.io/v3/ca203a8d992d4e6d8004877ece862910
 REACT_APP_ENS_CONTRACT=0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C
 REACT_APP_GOAT_COUNTER=GOAT_COUNTER_URL

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * https://opensea.io/assets/poap-v2?sortBy=assets_prod_main
 * https://etherscan.io/token/0x22c1f6050e56d2876009903609a2cc3fef83b415?a=0xf6b6f07862a02c85628b3a9688beae07fea9c863#inventory
 
-* https://api.poap.xyz/token/16815/image
+* https://api.poap.tech/token/16815/image
 
 ## Mainnet
 

--- a/netlify/functions/render.js
+++ b/netlify/functions/render.js
@@ -79,7 +79,7 @@ function dectectBot(userAgent) {
 
 const getEvent = async (id) => {
   try {
-    return await axios.get('https://api.poap.xyz/events/id/'+id)
+    return await axios.get('https://api.poap.tech/events/id/'+id)
   } catch (error) {
     console.error(error)
   }


### PR DESCRIPTION
## Summary

Making changes to migrate the current api.poap.xyz domain to api.poap.tech.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Deployment guidelines

1. Need to change the api env variable in the deployment to api.poap.tech. This means, in our Netlify environment, we need to change `REACT_APP_POAP_API_URL` to point to `https://api.poap.tech/`

## Testing

We should be able to:
- See the activity with corresponding poap metadata
- View more acivity with the top 3 events
- Explore events displayed on a grid fashion in the index page with corresponding metadata
- Inspect an event, see the event data and collectors

## Ticket

[FR-373](https://poap-devs.atlassian.net/browse/FR-373)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I didn't commit unnecessary logs
