### PR TITLE
Fix page breaking when the URL is not a valid URL format

### DIFF
--- a/src/pages/event.js
+++ b/src/pages/event.js
@@ -336,10 +336,15 @@ function tokenDetails(event, csv_data) {
     { value: event.start_date, key: 'Start date' },
     { value: event.end_date, key: 'End date' },
     { value: event.event_url, key: 'Website', render: (value) => {
-      let host = new URL(value).hostname
-      return (
-      <a href={value} className="href" target="_blank" rel="noopener noreferrer">{host}</a>
-      )
+      try {
+          let host = new URL(value).hostname;
+          return (
+              <a href={value} className="href" target="_blank" rel="noopener noreferrer">{host}</a>
+          )
+      } catch (e) {
+          return <></>
+      }
+
     }},
   ];
   if (Array.isArray(csv_data) && csv_data.length > 1) {


### PR DESCRIPTION
**This is a change to the LEGACY application**

## Summary

When the event URL bis not formatted correctly, the hole page does not load. 
Add a try catch to render that component

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Screenshots
Before:
<img width="559" alt="Screenshot 2022-09-20 at 10 50 11 AM" src="https://user-images.githubusercontent.com/19600590/191214707-977842b8-1efd-4e68-9b00-92d71a5c97c0.png">

After:
<img width="559" alt="Screenshot 2022-09-20 at 10 50 40 AM" src="https://user-images.githubusercontent.com/19600590/191214752-83f5e3d3-934b-4bd5-9f3e-a640601f7edb.png">



## Deployment guidelines

Merge it into the legacy branch

## Testing

Load the event 62214 in this PR and in the [legacy app](https://legacy.poap.gallery/r/event/62214)

## Ticket

[PLT-659](https://poap-devs.atlassian.net/browse/PLT-659)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I didn't commit unnecessary logs
