### PR TITLE
Fix check if event is loaded to track page view

### DIFF
--- a/src/pages/event.js
+++ b/src/pages/event.js
@@ -120,13 +120,13 @@ export function Event() {
   }, []);
 
   useEffect(() => {
-    if (succeededLoadingEvent()) {
+    if (succeededLoadingEvent() && !tableIsLoading) {
       trackPageView({
         href: window.location.href,
         documentTitle: `POAP Gallery - Event - ${event.name}`,
       });
     }
-  }, [event, succeededLoadingEvent]);
+  }, [event, succeededLoadingEvent, tableIsLoading]);
 
   useEffect(() => {
     // Get new batch of tokens

--- a/src/pages/event.js
+++ b/src/pages/event.js
@@ -120,13 +120,13 @@ export function Event() {
   }, []);
 
   useEffect(() => {
-    if (event) {
+    if (succeededLoadingEvent()) {
       trackPageView({
         href: window.location.href,
         documentTitle: `POAP Gallery - Event - ${event.name}`,
       });
     }
-  }, [event]);
+  }, [event, succeededLoadingEvent]);
 
   useEffect(() => {
     // Get new batch of tokens


### PR DESCRIPTION
## Summary

Fix `undefined` in Matomo track page title by correctly detecting event loaded.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
